### PR TITLE
remove prices-low option from nav

### DIFF
--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -56,9 +56,6 @@ class TopNav extends Component {
         <Link to="/" className={this.menuItemClass()} onClick={this.toggleClass} >
           What is Cleanapp?
         </Link>
-        <Link to="/" className={this.menuItemClass()} onClick={this.toggleClass} >
-          How We Keep the Prices Low
-        </Link>
         <Link
           to="/login"
           className={`${this.menuItemClass()} nav-item--bottom`}


### PR DESCRIPTION
removes 'how we keep our prices low' from top nav. Andreas realized he doesn't want to give out that information to possible competitors because the market is so untapped
